### PR TITLE
feat: Add tooling and documentation to support leaderboard result evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ uv run setup_env
 ```
 
 The `setup_env` takes care of the following:
-1.  Ensuring all dependencies are installed.
+1.  Installs all dependencies.
 2.  Configures the oracle agent with golden patches for testing.
 3.  Generates the `summary.json` for the dataset explorer.
 4.  Detects your host architecture (x86/AMD64 or ARM64) and builds the Docker images or exits gracefully if incompatible.
@@ -105,12 +105,34 @@ pytest --log-cli-level=INFO --verbose
 > You must have a Gemini API key configured for the test suite to pass.
 
 ## Visualize Results
-To visualize the results, you can use the HTML summary, generated with the following command:
+To visualize the results, you can generate an HTML summary which can help you understand what were the scores, see the patches, trajectories, and variations between multiple runs where available. 
+
+Generate the HTML summary with the following command:
 
 ```bash
-results --input-dir our
+results --input-dir out
 ```
 > Remember to change the input-dir to the directory of your choice if you decide to store the results elsewhere.
+
+### Reviewing the results used in the current Leaderboard
+If you'd like to deep-dive on the runs used for the current leaderboard, you must access the official release assets.
+
+We host the evaluation results, including trajectories and generated patches used to compute the leaderboard scores, via GitHub Releases on this repository. Due to GitHub's individual asset limits, we compress and split files exceeding 2GB into chunks.
+
+> [!IMPORTANT]
+> **To access and analyze the leaderboard results:**
+> Run the built-in downloader to automatically fetch and extract the results for the models you're interested in:
+>
+> ```bash
+> # Downloads and extracts gemini-3.1-pro-preview to results/v1_20260305/gemini-3.1-pro-preview
+> download_results --models gemini-3.1-pro-preview --dir results/v1_20260305
+> ```
+
+Once decompressed, you can generate the HTML summary for any of the leaderboard models using the `results` script:
+
+```bash
+results --input-dir results/v1_20260305/gemini-3.1-pro-preview
+```
 
 ## Detailed Documentation
 For more comprehensive guides and architectural details, refer to the following resources:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = "pytest:main"
 dataset = "utils.explorer.commands:app"
 prebuild_checks = "utils.docker.prebuild:main"
 results = "results.generate_task_html:main"
+download_results = "utils.download_results:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/harness_inference_tests/agent_infra_test.py
+++ b/tests/harness_inference_tests/agent_infra_test.py
@@ -269,4 +269,3 @@ def test_sanitize_model_name():
     )
     assert sanitize_model_name_for_path("openai/gpt-4") == "openai-gpt-4"
     assert sanitize_model_name_for_path("model") == "model"
-

--- a/tests/test_download_results.py
+++ b/tests/test_download_results.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from io import StringIO
+import os
+import argparse
+
+# Import the module to be tested
+from utils import download_results
+
+class TestDownloadResults(unittest.TestCase):
+
+    @patch('utils.download_results.urllib.request.urlopen')
+    @patch('utils.download_results.json.loads')
+    def test_fetch_release_assets_success(self, mock_json_loads, mock_urlopen):
+        # Mocking the GitHub API response
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{}'
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        # Mocking the JSON payload to match GitHub Releases API response structure (a dict with an 'assets' key)
+        mock_json_loads.return_value = {
+            "assets": [
+                {"name": "gemini-3.1-pro-preview.tar.gz", "browser_download_url": "http://example.com/gemini"},
+                {"name": "claude-sonnet-4-5.tar.gz", "browser_download_url": "http://example.com/claude"}
+            ]
+        }
+
+        assets = download_results.fetch_release_assets("test-org", "test-repo", "v1.0.0")
+
+        self.assertEqual(len(assets), 2)
+        # fetch_release_assets returns a list of dictionaries now, not a keyed dict
+        self.assertEqual(assets[0]["name"], "gemini-3.1-pro-preview.tar.gz")
+        self.assertEqual(assets[0]["browser_download_url"], "http://example.com/gemini")
+        self.assertEqual(assets[1]["name"], "claude-sonnet-4-5.tar.gz")
+        self.assertEqual(assets[1]["browser_download_url"], "http://example.com/claude")
+        mock_urlopen.assert_called_once()
+
+    @patch('utils.download_results.urllib.request.urlopen')
+    def test_fetch_release_assets_failure(self, mock_urlopen):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = HTTPError("url", 404, "Not Found", {}, None)
+        
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            with self.assertRaises(SystemExit):
+                download_results.fetch_release_assets("test-org", "test-repo", "v1.0.0")
+            
+            output = fake_out.getvalue()
+            self.assertIn("Error fetching release: HTTP 404 - Not Found", output)
+
+    @patch('utils.download_results.argparse.ArgumentParser.parse_args')
+    def test_argument_parsing_in_main(self, mock_parse_args):
+        # We just want to ensure main sets up arguments correctly. 
+        # Since logic is intertwined in main(), we can mock parse_args to return specific values
+        # and mock fetch_release_assets to prevent actual execution.
+        mock_args = argparse.Namespace(
+            models=["all"], dir=".", org="android-bench", repo="results", tag="v1.0.0"
+        )
+        mock_parse_args.return_value = mock_args
+        
+        with patch('utils.download_results.fetch_release_assets') as mock_fetch:
+            # We also need to mock sys.exit to catch the empty assets exit
+            with patch('sys.exit'):
+                with patch('sys.stdout', new=StringIO()):
+                    download_results.main()
+                    mock_fetch.assert_called_once_with("android-bench", "results", "v1.0.0")
+
+    @patch('utils.download_results.urllib.request.urlretrieve')
+    def test_download_file(self, mock_urlretrieve):
+        # We mock urlretrieve which is now used in download_results
+
+        with patch('sys.stdout', new=StringIO()):
+            download_results.download_file("http://example.com/test.gz", "test_out.gz", "test.gz")
+
+        mock_urlretrieve.assert_called_once_with("http://example.com/test.gz", "test_out.gz")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils/test_download_results.py
+++ b/tests/utils/test_download_results.py
@@ -3,29 +3,36 @@ from unittest.mock import patch, MagicMock
 from io import StringIO
 import os
 import argparse
-
-# Import the module to be tested
 from utils import download_results
+
 
 class TestDownloadResults(unittest.TestCase):
 
-    @patch('utils.download_results.urllib.request.urlopen')
-    @patch('utils.download_results.json.loads')
+    @patch("utils.download_results.urllib.request.urlopen")
+    @patch("utils.download_results.json.loads")
     def test_fetch_release_assets_success(self, mock_json_loads, mock_urlopen):
         # Mocking the GitHub API response
         mock_response = MagicMock()
-        mock_response.read.return_value = b'{}'
+        mock_response.read.return_value = b"{}"
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
         # Mocking the JSON payload to match GitHub Releases API response structure (a dict with an 'assets' key)
         mock_json_loads.return_value = {
             "assets": [
-                {"name": "gemini-3.1-pro-preview.tar.gz", "browser_download_url": "http://example.com/gemini"},
-                {"name": "claude-sonnet-4-5.tar.gz", "browser_download_url": "http://example.com/claude"}
+                {
+                    "name": "gemini-3.1-pro-preview.tar.gz",
+                    "browser_download_url": "http://example.com/gemini",
+                },
+                {
+                    "name": "claude-sonnet-4-5.tar.gz",
+                    "browser_download_url": "http://example.com/claude",
+                },
             ]
         }
 
-        assets = download_results.fetch_release_assets("test-org", "test-repo", "v1.0.0")
+        assets = download_results.fetch_release_assets(
+            "test-org", "test-repo", "v1.0.0"
+        )
 
         self.assertEqual(len(assets), 2)
         # fetch_release_assets returns a list of dictionaries now, not a keyed dict
@@ -35,43 +42,55 @@ class TestDownloadResults(unittest.TestCase):
         self.assertEqual(assets[1]["browser_download_url"], "http://example.com/claude")
         mock_urlopen.assert_called_once()
 
-    @patch('utils.download_results.urllib.request.urlopen')
+    @patch("utils.download_results.urllib.request.urlopen")
     def test_fetch_release_assets_failure(self, mock_urlopen):
         from urllib.error import HTTPError
+
         mock_urlopen.side_effect = HTTPError("url", 404, "Not Found", {}, None)
-        
-        with patch('sys.stdout', new=StringIO()) as fake_out:
+
+        with patch("sys.stdout", new=StringIO()) as fake_out:
             with self.assertRaises(SystemExit):
                 download_results.fetch_release_assets("test-org", "test-repo", "v1.0.0")
-            
+
             output = fake_out.getvalue()
             self.assertIn("Error fetching release: HTTP 404 - Not Found", output)
 
-    @patch('utils.download_results.argparse.ArgumentParser.parse_args')
+    @patch("utils.download_results.argparse.ArgumentParser.parse_args")
     def test_argument_parsing_in_main(self, mock_parse_args):
-        # We just want to ensure main sets up arguments correctly. 
+        # We just want to ensure main sets up arguments correctly.
         # Since logic is intertwined in main(), we can mock parse_args to return specific values
         # and mock fetch_release_assets to prevent actual execution.
         mock_args = argparse.Namespace(
-            models=["all"], dir=".", org="android-bench", repo="results", tag="v1.0.0"
+            models=["all"],
+            dir=".",
+            org="android-bench",
+            repo="android-bench",
+            tag="v1.0.0",
         )
         mock_parse_args.return_value = mock_args
-        
-        with patch('utils.download_results.fetch_release_assets') as mock_fetch:
-            # We also need to mock sys.exit to catch the empty assets exit
-            with patch('sys.exit'):
-                with patch('sys.stdout', new=StringIO()):
-                    download_results.main()
-                    mock_fetch.assert_called_once_with("android-bench", "results", "v1.0.0")
 
-    @patch('utils.download_results.urllib.request.urlretrieve')
+        with patch("utils.download_results.fetch_release_assets") as mock_fetch:
+            # We also need to mock sys.exit to catch the empty assets exit
+            with patch("sys.exit"):
+                with patch("sys.stdout", new=StringIO()):
+                    download_results.main()
+                    mock_fetch.assert_called_once_with(
+                        "android-bench", "android-bench", "v1.0.0"
+                    )
+
+    @patch("utils.download_results.urllib.request.urlretrieve")
     def test_download_file(self, mock_urlretrieve):
         # We mock urlretrieve which is now used in download_results
 
-        with patch('sys.stdout', new=StringIO()):
-            download_results.download_file("http://example.com/test.gz", "test_out.gz", "test.gz")
+        with patch("sys.stdout", new=StringIO()):
+            download_results.download_file(
+                "http://example.com/test.gz", "test_out.gz", "test.gz"
+            )
 
-        mock_urlretrieve.assert_called_once_with("http://example.com/test.gz", "test_out.gz")
+        mock_urlretrieve.assert_called_once_with(
+            "http://example.com/test.gz", "test_out.gz"
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/utils/download_results.py
+++ b/utils/download_results.py
@@ -2,7 +2,7 @@
 """
 Android Bench Results Downloader
 
-This script downloads and extracts compiled model results from the Android Bench 
+This script downloads and extracts compiled model results from the Android Bench
 GitHub release directly to the specified directory.
 
 Usage:
@@ -22,17 +22,18 @@ import urllib.request
 from pathlib import Path
 from urllib.error import HTTPError
 
+
 def fetch_release_assets(org, repo, tag):
     """Fetches the list of assets available in the release via GitHub API."""
     api_url = f"https://api.github.com/repos/{org}/{repo}/releases/tags/{tag}"
     print(f"Fetching release information for {org}/{repo} @ {tag}...")
     req = urllib.request.Request(api_url)
-    req.add_header('Accept', 'application/vnd.github.v3+json')
-    
+    req.add_header("Accept", "application/vnd.github.v3+json")
+
     try:
         with urllib.request.urlopen(req) as response:
             data = json.loads(response.read().decode())
-            return data.get('assets', [])
+            return data.get("assets", [])
     except HTTPError as e:
         print(f"Error fetching release: HTTP {e.code} - {e.reason}")
         print("Please verify the repository name, organization, and release tag.")
@@ -40,6 +41,7 @@ def fetch_release_assets(org, repo, tag):
     except Exception as e:
         print(f"Failed to fetch release information: {e}")
         sys.exit(1)
+
 
 def download_file(url, dest_path, filename):
     """Downloads a file with a simple progress indicator."""
@@ -50,31 +52,32 @@ def download_file(url, dest_path, filename):
         print(f"Failed to download {filename}: {e}")
         sys.exit(1)
 
+
 def assemble_and_extract(model_name, parts, target_dir):
     """Assembles chunked tar.gz parts and extracts them."""
     print(f"\nExtracting {model_name}...")
-    
+
     # Sort parts alphabetically to ensure correct assembly order
     parts.sort()
-    
+
     # Create a temporary file to hold the assembled tar.gz
     temp_tar_path = Path(target_dir) / f"{model_name}_assembled.tar.gz"
-    
+
     try:
         # Assemble
-        with open(temp_tar_path, 'wb') as outfile:
+        with open(temp_tar_path, "wb") as outfile:
             for part in parts:
                 print(f"  Reading {os.path.basename(part)}...")
-                with open(part, 'rb') as infile:
+                with open(part, "rb") as infile:
                     shutil.copyfileobj(infile, outfile)
-        
+
         # Extract
         print(f"  Unpacking archive...")
-        with tarfile.open(temp_tar_path, 'r:gz') as tar:
+        with tarfile.open(temp_tar_path, "r:gz") as tar:
             tar.extractall(path=target_dir)
-            
+
         print(f"✓ Successfully extracted {model_name} to {target_dir}")
-        
+
     except Exception as e:
         print(f"Error during assembly or extraction for {model_name}: {e}")
     finally:
@@ -84,38 +87,30 @@ def assemble_and_extract(model_name, parts, target_dir):
         for part in parts:
             Path(part).unlink()
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Download Android Bench model results.")
+    parser = argparse.ArgumentParser(
+        description="Download Android Bench model results."
+    )
     parser.add_argument(
-        "--models", 
-        nargs="+", 
+        "--models",
+        nargs="+",
         required=True,
-        help="List of models to download (e.g., gemini-3.1-pro-preview), or 'all' to download everything."
+        help="List of models to download (e.g., gemini-3.1-pro-preview), or 'all' to download everything.",
     )
     parser.add_argument(
-        "--dir", 
-        type=str, 
-        default=".", 
-        help="Target directory to extract the results into. Defaults to current directory."
+        "--dir",
+        type=str,
+        default=".",
+        help="Target directory to extract the results into. Defaults to current directory.",
     )
     parser.add_argument(
-        "--org", 
-        type=str, 
-        default="android-bench", 
-        help="GitHub organization."
+        "--org", type=str, default="android-bench", help="GitHub organization."
     )
     parser.add_argument(
-        "--repo", 
-        type=str, 
-        default="results", 
-        help="GitHub repository."
+        "--repo", type=str, default="results", help="GitHub repository."
     )
-    parser.add_argument(
-        "--tag", 
-        type=str, 
-        default="v1.0.0", 
-        help="Release tag."
-    )
+    parser.add_argument("--tag", type=str, default="v1.0.0", help="Release tag.")
     args = parser.parse_args()
 
     assets = fetch_release_assets(args.org, args.repo, args.tag)
@@ -125,30 +120,30 @@ def main():
 
     target_dir = Path(args.dir)
     target_dir.mkdir(parents=True, exist_ok=True)
-    
+
     downloaded_parts_by_model = {}
     models_to_fetch = set(args.models)
     download_all = "all" in [m.lower() for m in models_to_fetch]
 
     total_downloaded = 0
-    
+
     for asset in assets:
-        name = asset['name']
-        download_url = asset['browser_download_url']
-        
+        name = asset["name"]
+        download_url = asset["browser_download_url"]
+
         # Asset format: {model_name}.tar.gz or {model_name}.tar.gz.part_aa
         if ".tar.gz" not in name:
             continue
-            
+
         model_name = name.split(".tar.gz")[0]
-        
+
         if not download_all and model_name not in models_to_fetch:
             continue
-            
+
         # Register model for assembly
         if model_name not in downloaded_parts_by_model:
             downloaded_parts_by_model[model_name] = []
-            
+
         dest_path = target_dir / name
         download_file(download_url, dest_path, name)
         downloaded_parts_by_model[model_name].append(str(dest_path))
@@ -157,7 +152,15 @@ def main():
     if total_downloaded == 0:
         print("\nNo matching models found in the release assets.")
         print("Available models in release:")
-        available = list(set([a['name'].split(".tar.gz")[0] for a in assets if ".tar.gz" in a['name']]))
+        available = list(
+            set(
+                [
+                    a["name"].split(".tar.gz")[0]
+                    for a in assets
+                    if ".tar.gz" in a["name"]
+                ]
+            )
+        )
         for m in sorted(available):
             print(f"  - {m}")
         sys.exit(1)
@@ -165,6 +168,7 @@ def main():
     # Process each model
     for model_name, parts in downloaded_parts_by_model.items():
         assemble_and_extract(model_name, parts, target_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/utils/download_results.py
+++ b/utils/download_results.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Android Bench Results Downloader
+
+This script downloads and extracts compiled model results from the Android Bench 
+GitHub release directly to the specified directory.
+
+Usage:
+  python3 download_results.py --models gemini-3.1-pro-preview claude-opus-4-5
+  python3 download_results.py --models all
+"""
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+from urllib.error import HTTPError
+
+def fetch_release_assets(org, repo, tag):
+    """Fetches the list of assets available in the release via GitHub API."""
+    api_url = f"https://api.github.com/repos/{org}/{repo}/releases/tags/{tag}"
+    print(f"Fetching release information for {org}/{repo} @ {tag}...")
+    req = urllib.request.Request(api_url)
+    req.add_header('Accept', 'application/vnd.github.v3+json')
+    
+    try:
+        with urllib.request.urlopen(req) as response:
+            data = json.loads(response.read().decode())
+            return data.get('assets', [])
+    except HTTPError as e:
+        print(f"Error fetching release: HTTP {e.code} - {e.reason}")
+        print("Please verify the repository name, organization, and release tag.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Failed to fetch release information: {e}")
+        sys.exit(1)
+
+def download_file(url, dest_path, filename):
+    """Downloads a file with a simple progress indicator."""
+    print(f"Downloading {filename}...")
+    try:
+        urllib.request.urlretrieve(url, dest_path)
+    except Exception as e:
+        print(f"Failed to download {filename}: {e}")
+        sys.exit(1)
+
+def assemble_and_extract(model_name, parts, target_dir):
+    """Assembles chunked tar.gz parts and extracts them."""
+    print(f"\nExtracting {model_name}...")
+    
+    # Sort parts alphabetically to ensure correct assembly order
+    parts.sort()
+    
+    # Create a temporary file to hold the assembled tar.gz
+    temp_tar_path = Path(target_dir) / f"{model_name}_assembled.tar.gz"
+    
+    try:
+        # Assemble
+        with open(temp_tar_path, 'wb') as outfile:
+            for part in parts:
+                print(f"  Reading {os.path.basename(part)}...")
+                with open(part, 'rb') as infile:
+                    shutil.copyfileobj(infile, outfile)
+        
+        # Extract
+        print(f"  Unpacking archive...")
+        with tarfile.open(temp_tar_path, 'r:gz') as tar:
+            tar.extractall(path=target_dir)
+            
+        print(f"✓ Successfully extracted {model_name} to {target_dir}")
+        
+    except Exception as e:
+        print(f"Error during assembly or extraction for {model_name}: {e}")
+    finally:
+        # Cleanup assembled tar and parts
+        if temp_tar_path.exists():
+            temp_tar_path.unlink()
+        for part in parts:
+            Path(part).unlink()
+
+def main():
+    parser = argparse.ArgumentParser(description="Download Android Bench model results.")
+    parser.add_argument(
+        "--models", 
+        nargs="+", 
+        required=True,
+        help="List of models to download (e.g., gemini-3.1-pro-preview), or 'all' to download everything."
+    )
+    parser.add_argument(
+        "--dir", 
+        type=str, 
+        default=".", 
+        help="Target directory to extract the results into. Defaults to current directory."
+    )
+    parser.add_argument(
+        "--org", 
+        type=str, 
+        default="android-bench", 
+        help="GitHub organization."
+    )
+    parser.add_argument(
+        "--repo", 
+        type=str, 
+        default="results", 
+        help="GitHub repository."
+    )
+    parser.add_argument(
+        "--tag", 
+        type=str, 
+        default="v1.0.0", 
+        help="Release tag."
+    )
+    args = parser.parse_args()
+
+    assets = fetch_release_assets(args.org, args.repo, args.tag)
+    if not assets:
+        print("No assets found in the release.")
+        sys.exit(1)
+
+    target_dir = Path(args.dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    
+    downloaded_parts_by_model = {}
+    models_to_fetch = set(args.models)
+    download_all = "all" in [m.lower() for m in models_to_fetch]
+
+    total_downloaded = 0
+    
+    for asset in assets:
+        name = asset['name']
+        download_url = asset['browser_download_url']
+        
+        # Asset format: {model_name}.tar.gz or {model_name}.tar.gz.part_aa
+        if ".tar.gz" not in name:
+            continue
+            
+        model_name = name.split(".tar.gz")[0]
+        
+        if not download_all and model_name not in models_to_fetch:
+            continue
+            
+        # Register model for assembly
+        if model_name not in downloaded_parts_by_model:
+            downloaded_parts_by_model[model_name] = []
+            
+        dest_path = target_dir / name
+        download_file(download_url, dest_path, name)
+        downloaded_parts_by_model[model_name].append(str(dest_path))
+        total_downloaded += 1
+
+    if total_downloaded == 0:
+        print("\nNo matching models found in the release assets.")
+        print("Available models in release:")
+        available = list(set([a['name'].split(".tar.gz")[0] for a in assets if ".tar.gz" in a['name']]))
+        for m in sorted(available):
+            print(f"  - {m}")
+        sys.exit(1)
+
+    # Process each model
+    for model_name, parts in downloaded_parts_by_model.items():
+        assemble_and_extract(model_name, parts, target_dir)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces tooling and documentation required to allow folks to download, assemble, and visualise the results used in the public leaderboard calculations.

The `download_results` CLI tool automates fetching and extracting model evaluation results from GitHub releases. This streamlines access to large datasets (e.g., Gemini and Claude trajectories) that are split into multiple parts due to platform limits.